### PR TITLE
Added QUERY_ALL_PACKAGES to fix NameNotFoundException on getPackageInfo

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/kuro/signreader/MainActivity.java
+++ b/app/src/main/java/com/kuro/signreader/MainActivity.java
@@ -7,6 +7,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.Signature;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Environment;
 import android.util.Base64;
 import android.view.View;
 import android.widget.Button;

--- a/app/src/main/java/com/kuro/signreader/MainActivity.java
+++ b/app/src/main/java/com/kuro/signreader/MainActivity.java
@@ -89,7 +89,7 @@ public class MainActivity extends Activity {
                     StringBuilder sb = new StringBuilder();
                     sb.append(resultBase64.getText().toString() + "\n");
                     sb.append(resultCpp.getText().toString() + "\n");
-                    FileOutputStream fos = new FileOutputStream(new File("/sdcard", path));
+                    FileOutputStream fos = new FileOutputStream(new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), path));
                     fos.write(sb.toString().getBytes());
                     fos.close();
                     Toast.makeText(MainActivity.this, "Saved to " + path, Toast.LENGTH_SHORT).show();


### PR DESCRIPTION
### The Issue
Tested on a device running Android 13: the `getPackageInfo` call throws a `android.content.pm.PackageManager$NameNotFoundException` for most package names.
To be specific, the issue seems to affect only user applications (unlike `com.android.vending`).
![image](https://github.com/aimardcr/APKSignReader/assets/119003089/840e8910-f22c-4fdd-96ff-52604ddee842)

This results in nothing happening upon tapping the `Get Sign` button even when the user inputs a valid package name.

### Explanation and Fix
https://developer.android.com/training/package-visibility#intent-signature

Simply adding the `QUERY_ALL_PACKAGES` permission does the trick, and the application then works as expected.